### PR TITLE
Fix #32: scipy>=1.15 compat + lamindb modules flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ pip install scdataloader
 # or
 pip install scDataLoader[dev] # for dev dependencies
 
-lamin init --storage ./testdb --name test --schema bionty
+lamin init --storage ./testdb --name test --modules bionty
 ```
 
 if you start with lamin and had to do a `lamin init`, you will also need to
@@ -107,7 +107,7 @@ pip install -e scDataLoader[dev]
 
 ```python
 # initialize a local lamin database
-#! lamin init --storage ./cellxgene --name cellxgene --schema bionty
+#! lamin init --storage ./cellxgene --name cellxgene --modules bionty
 from scdataloader import utils, Preprocessor, DataModule
 
 
@@ -143,7 +143,7 @@ more
 
 ```python
 # initialize a local lamin database
-#! lamin init --storage ./cellxgene --name cellxgene --schema bionty
+#! lamin init --storage ./cellxgene --name cellxgene --modules bionty
 
 from scdataloader import utils, Preprocessor, SimpleAnnDataset, Collator, DataLoader
 
@@ -203,7 +203,7 @@ scDataLoader as a script (a notebook version is also available in
 
 ```python
 # initialize a local lamin database
-#! lamin init --storage ./cellxgene --name cellxgene --schema bionty
+#! lamin init --storage ./cellxgene --name cellxgene --modules bionty
 
 from scdataloader import utils
 from scdataloader.preprocess import LaminPreprocessor, additional_postprocess, additional_preprocess

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ pip install scdataloader
 # or
 pip install scDataLoader[dev] # for dev dependencies
 
-lamin init --storage ./testdb --name test --schema bionty
+lamin init --storage ./testdb --name test --modules bionty
 ```
 
 if you start with lamin and had to do a `lamin init`, you will also need to
@@ -97,7 +97,7 @@ pip install -e scDataLoader[dev]
 
 ```python
 # initialize a local lamin database
-#! lamin init --storage ./cellxgene --name cellxgene --schema bionty
+#! lamin init --storage ./cellxgene --name cellxgene --modules bionty
 from scdataloader import utils, Preprocessor, DataModule
 
 
@@ -133,7 +133,7 @@ more
 
 ```python
 # initialize a local lamin database
-#! lamin init --storage ./cellxgene --name cellxgene --schema bionty
+#! lamin init --storage ./cellxgene --name cellxgene --modules bionty
 
 from scdataloader import utils, Preprocessor, SimpleAnnDataset, Collator, DataLoader
 
@@ -193,7 +193,7 @@ scDataLoader as a script (a notebook version is also available in
 
 ```python
 # initialize a local lamin database
-#! lamin init --storage ./cellxgene --name cellxgene --schema bionty
+#! lamin init --storage ./cellxgene --name cellxgene --modules bionty
 
 from scdataloader import utils
 from scdataloader.preprocess import LaminPreprocessor, additional_postprocess, additional_preprocess

--- a/docs/notebooks/1_download_and_preprocess.ipynb
+++ b/docs/notebooks/1_download_and_preprocess.ipynb
@@ -30,7 +30,7 @@
    ],
    "source": [
     "# initialize a local lamin database\n",
-    "# !lamin init --storage ~/scdataloader --schema bionty\n",
+    "# !lamin init --storage ~/scdataloader --modules bionty\n",
     "! lamin load scdataloader"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scdataloader"
-version = "2.1.2"
+version = "2.1.3"
 description = "a dataloader for single cell data in lamindb"
 authors = [
     {name = "jkobject", email = "jkobject@gmail.com"}

--- a/scdataloader/preprocess.py
+++ b/scdataloader/preprocess.py
@@ -866,10 +866,12 @@ def additional_postprocess(adata):
 
     adata.obs[NEWOBS] = adata.obs[NEWOBS].map(relab)
 
+    # scipy >= 1.15 no longer accepts a pandas Series for sparse boolean
+    # indexing of AnnData.X, so cast the mask to a numpy array.
     cluster_means = pd.DataFrame(
         np.array(
             [
-                adata.X[adata.obs[NEWOBS] == i].mean(axis=0)
+                adata.X[(adata.obs[NEWOBS] == i).to_numpy()].mean(axis=0)
                 for i in adata.obs[NEWOBS].unique()
             ]
         )[:, 0, :],


### PR DESCRIPTION
Fixes #32.

## Changes
- `preprocess.additional_postprocess`: cast `pd.Series` boolean mask to numpy before indexing `AnnData.X`. scipy >= 1.15 dropped the implicit relaxed indexing of sparse arrays with pandas Series (see scipy/scipy@66ec333), so `adata.X[adata.obs[NEWOBS] == i]` raises `AttributeError: 'Series' object has no attribute 'nonzero'`. Casting with `.to_numpy()` fixes the regression and is forward-compatible.
- Docs/README: replace deprecated `lamin init --schema bionty` with `--modules bionty` (lamindb 2.1.x). Also matches the reporter's working notebook ([gist](https://gist.github.com/Stfort52/c66bcfeef667963609d06e964d45eb39)).
- Bumped version to `2.1.3` so scPRINT-2 can pin to the fixed release.

## Test plan
- Ran the failing snippet (`additional_postprocess(adata)` with a mock AnnData) on scipy 1.15 — no more `AttributeError`.

CC @Stfort52 — thanks for the very thorough bug report (including the scipy commit pointer).